### PR TITLE
login/register form frontend & minor styling/navbar fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@
 @import "components/container";
 @import "components/loginbox";
 @import "components/navbar";
+@import "components/singupbox";
 
 .text-white {
   font-family: "Rajdhani", sans-serif;

--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,5 +1,5 @@
 .alert {
-  position: fixed;
+  position: absolute !important;
   bottom: 16px;
   right: 16px;
   z-index: 1000;

--- a/app/assets/stylesheets/components/_singupbox.scss
+++ b/app/assets/stylesheets/components/_singupbox.scss
@@ -1,0 +1,79 @@
+.singupContainer {
+  margin: 5% 1% !important;
+  padding: 3% 5% !important;
+  justify-content: center;
+}
+
+abbr {
+  text-decoration: none !important;
+}
+
+.singupForm {
+  width: 250px;
+}
+
+.singupForm .form-text, .logintext, .fgtlink {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 11px;
+  color: #3ca0e7;
+  letter-spacing: 0.5px;
+  margin-bottom: 2px;
+}
+
+.singupForm label{
+  font-size: 14px;
+  letter-spacing: 1px;
+}
+
+.singupContainer label, .singupContainer h2, .singupContainer a, .singupbtn input {
+  font-family: "Rajdhani", sans-serif;
+  color: white;
+}
+
+.singupContainer h2 {
+  letter-spacing: 3px;
+  margin-bottom: 15%;
+}
+
+.password  {
+  margin-bottom: 0px !important;
+}
+
+.singupbtn  {
+  margin-bottom: 40px;
+  cursor: pointer;
+}
+
+.singupbtn input  {
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+  padding: 0px !important;
+  margin: 0px !important;
+}
+
+.singupbtn input:hover  {
+  background: none;
+  color: white;
+}
+
+.user_remember_me .form-check{
+  display: flex;
+  justify-content: center;
+}
+
+.user_remember_me label{
+  margin-left: 10px !important;
+}
+
+.logintext a:hover, .fgtlink:hover {
+  color:white;
+  border-bottom: 1px solid white;
+}
+
+.invalid-feedback {
+  font-family: "Rajdhani", sans-serif;
+  font-size: 11px !important;
+  letter-spacing: 0.5px;
+  margin-bottom: 0px !important;
+}

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,18 +1,19 @@
-<h2>Forgot your password?</h2>
+<div class="text-center vh-100 d-flex justify-content-center align-items-center homepagebackground">
+  <div class="card-body d-flex flex-column singupContainer">
+    <h2>Forgot your password?</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_notification %>
+    <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "d-flex flex-column align-items-center" }) do |f| %>
+      <div class="form-inputs singupForm">
+        <%= f.input :email,
+                    required: true,
+                    autofocus: true,
+                    input_html: { autocomplete: "email" } %>
+      </div>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
+      <div class="form-actions singupbtn btn-dark">
+        <%= f.button :submit, "Confirm" %>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,25 +1,26 @@
-<h2>Sign up</h2>
+<div class="text-center vh-100 d-flex justify-content-center align-items-center homepagebackground">
+  <div class="card-body d-flex flex-column singupContainer">
+    <h2>Sing up</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
+    <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "d-flex flex-column align-items-center" }) do |f| %>
+      <div class="form-inputs singupForm">
+        <%= f.input :email,
+                    required: true,
+                    autofocus: true,
+                    input_html: { autocomplete: "email" }%>
+        <%= f.input :password,
+                    required: true,
+                    hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                    input_html: { autocomplete: "new-password" } %>
+        <%= f.input :password_confirmation,
+                    required: true,
+                    input_html: { autocomplete: "new-password" } %>
+      </div>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
-                required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
+      <div class="form-actions singupbtn btn-dark">
+        <%= f.button :submit, "Sign up" %>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,20 +1,23 @@
-<h2>Log in</h2>
+<div class="text-center vh-100 d-flex justify-content-center align-items-center homepagebackground">
+  <div class="card-body d-flex flex-column singupContainer">
+    <h2>Log in</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+    <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "d-flex flex-column align-items-center" }) do |f| %>
+      <div class="form-inputs singupForm">
+        <%= f.input :email,
+                    required: false,
+                    autofocus: true,
+                    input_html: { autocomplete: "email" } %>
+        <%= f.input :password,
+                    required: false,
+                    input_html: { autocomplete: "current-password" } %>
+        <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+      </div>
+
+      <div class="form-actions singupbtn btn-dark">
+        <%= f.button :submit, "Log in" %>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,13 +1,13 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <p class="logintext">Already have an account? <%= link_to "Log in", new_session_path(resource_name) %> </p>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "logintext, fgtlink" %>
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <p class="logintext">Don't have an account yet? <%= link_to "Sign up", new_registration_path(resource_name) %> </p>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,13 +2,16 @@
 
   <div class="w-100" style="margin-bottom: 110px;">
     <div class="d-flex flex-column align-items-center" >
-      <div class="sparkletitle d-flex flex-wrap-reverse" >
+      <div class="sparkletitle d-flex flex-wrap-reverse justify-content justify-content-around w-100" style="padding: 6% 1% 0% 1% !important;">
+        <div style="width: 25%; margin: 0px; text-align: -webkit-right;">
           <%= link_to events_path, class: "btn-dark mt-1" do %>
             <i class="fa-solid fa-chevron-left" style="padding-right:10px;"></i> Back to Dashboard
           <% end %>
-        <p style="width: 930px; margin: 0px; ">event details</p>
-
         </div>
+        <p style="width: 50%; margin: 0px; ">event details</p>
+        <div style="width: 25%; margin: 0px; "></div>
+      </div>
+
           <div class="d-flex justify-content-center">
             <div class="">
               <div class="eventsdetail ml-2 d-flex flex-wrap justify-content-center" >

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,10 @@
-<div class="navbar navbar-expand-sm navbar-light navbar-lewagon bg-transparent" >
+<% if user_signed_in? %>
+  <div class="navbar navbar-expand-sm navbar-light navbar-lewagon bg-transparent" >
+<% else %>
+  <div class="navbar navbar-expand-sm navbar-light navbar-lewagon bg-transparent" style="background: #101b38 !important;">
+<% end %>
   <div class="container-fluid" style="padding: 0% 7%;">
-    <%= link_to "#", class: "navbar-brand" do %>
+    <%= link_to "/", class: "navbar-brand" do %>
       <%= image_tag "syncsparkle.png", class: "logo-img", alt: "Your Logo"%>
     <% end %>
 


### PR DESCRIPTION
Login/register form and forgotten passwort frontend. Error messages match the styling of the forms now and appear bottom right, instead of below the Navbar. Navbar is now transparent in all pages if user is logged in, but it does look weird in the "login/register" form because of the static color in the not signed in landing page. 